### PR TITLE
update docker image tag to v1.2-v2.1.3

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -48,7 +48,7 @@ then
   fi
 fi
 
-DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools:v1.2-v2.1.2"
+DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools:v1.2-v2.1.3"
 
 SUFFIX=$(echo $(basename ${SCRIPT_DIR}) | base64 | sed -E "s/[^a-zA-Z0-9_.-]//g" | sed -E "s/.*(.{5})/\1/g")
 CONTAINER_NAME="cli-tools-${SUFFIX}"


### PR DESCRIPTION
moving pinned version to one with permissions fixes for ibmcloud cli plugins

Signed-off-by: Tim Robinson <timroster@gmail.com>