### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/verify-workflow-runner.yaml
+++ b/.github/workflows/verify-workflow-runner.yaml
@@ -92,7 +92,7 @@ jobs:
           NAME_PREFIX="${FLAVOR_CHAR}${STORAGE_CHAR}-${RANDOM_PREFIX}-infra"
           
           echo "Name prefix: $NAME_PREFIX"
-          echo "::set-output name=name-prefix::$NAME_PREFIX"
+          echo "name-prefix=$NAME_PREFIX" >> "$GITHUB_OUTPUT"
 
       - name: Setup workspace - ${{ matrix.flavor }},${{ matrix.storage }}
         shell: bash

--- a/.github/workflows/verify-workflow.yaml
+++ b/.github/workflows/verify-workflow.yaml
@@ -61,7 +61,7 @@ jobs:
           NAME_PREFIX="${FLAVOR_CHAR}${STORAGE_CHAR}-${RANDOM_PREFIX}-infra"
           
           echo "Name prefix: $NAME_PREFIX"
-          echo "::set-output name=name-prefix::$NAME_PREFIX"
+          echo "name-prefix=$NAME_PREFIX" >> "$GITHUB_OUTPUT"
 
       - name: Setup workspace - ${{ matrix.flavor }},${{ matrix.storage }}
         shell: bash


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter